### PR TITLE
Closes Job#9 Add role-specific list on maintenance page. #22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
  - Updated config/config.php and autoload.php so that user roles will work.
  - Added pagination in maintenance page.
  - Enabled task-completion in task list page.
+ - Updated maintenance page to enable role-specific list on it.
 
 ## [version 1.0.0 released] - 2017-10-12
 

--- a/application/controllers/Mtce.php
+++ b/application/controllers/Mtce.php
@@ -25,7 +25,10 @@ class Mtce extends Application {
         {
             if (!empty($task->status))
                 $task->status = $this->app->status($task->status);
-            $result .= $this->parser->parse('oneitem', (array) $task, true);
+            if ($role == ROLE_OWNER)
+                $result .= $this->parser->parse('oneitemx', (array) $task, true);
+            else
+                $result .= $this->parser->parse('oneitem', (array) $task, true);
         }
         $this->data['display_tasks'] = $result;
 
@@ -52,6 +55,9 @@ class Mtce extends Application {
         }
         
         $this->data['pagination'] = $this->pagenav($num);
+        $role = $this->session->userdata('userrole');
+        if ($role == ROLE_OWNER) 
+        $this->data['pagination'] .= $this->parser->parse('itemadd',[], true);
         $this->show_page($tasks);
     }
     

--- a/application/views/itemadd.php
+++ b/application/views/itemadd.php
@@ -1,0 +1,1 @@
+<a href="/mtce/add"><input type="button" value="Add a new todo item"/></a>

--- a/application/views/oneitemx.php
+++ b/application/views/oneitemx.php
@@ -1,0 +1,5 @@
+<tr>
+        <td><a href="/mtce/edit/{id}"><input type="button" value="{id}"/></a></td>
+        <td>{task}</td>
+        <td>{status}</td>
+</tr>


### PR DESCRIPTION
Update Mtce.php controller to enable role-specific list.
Add a view fragment for "add item" button on maintenance page.
Add a view page for the owner role to add and edit items.
Update the changelog.
Resolved #22